### PR TITLE
Revert "Bump connection-string from 1.1.0 to 4.3.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@snapshot-labs/sx": "^0.1.0-beta.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",
-    "connection-string": "^4.3.5",
+    "connection-string": "^1.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
     "eslint": "^6.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,10 +931,10 @@ configstore@^5.0.1:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-connection-string@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/connection-string/-/connection-string-4.3.5.tgz#02f725bc3f67a1f764c5fe5d8b986959ca3d9de5"
-  integrity sha512-ayXcReF4FoYTUCKxN8Z4bXDKek6O2w5/udkXH42Sv17k9saPW9XkMUJc4nE2CgQRRvBTqkmVsQstXYb9f99j4w==
+connection-string@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/connection-string/-/connection-string-1.1.0.tgz#3d37d8933210548f7bee752426e948cdd88663a0"
+  integrity sha512-uWTk8bs+jczX5D0ptKk7hldRMtp4eqty8SyTS1lKZs24VOQRsGGwLAUUvj1+egd+LxYfDfkiPSm4bFp9LTgrbQ==
 
 content-disposition@0.5.3:
   version "0.5.3"


### PR DESCRIPTION
Reverts snapshot-labs/sx-api#1