### PR TITLE
fix: disable pretty print in production

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const schema = fs.readFileSync(schemaFile, 'utf8');
 
 const checkpoint = new Checkpoint(config, writer, schema, checkpoints, {
   logLevel: LogLevel.Info,
-  prettifyLogs: true
+  prettifyLogs: process.env.NODE_ENV !== 'production'
 });
 checkpoint.reset();
 checkpoint.start();


### PR DESCRIPTION
This disables pretty printing in production. This is because the pretty
print functionality requires a pino-pretty package to be installed and
that is currently only a dev dependency.