### PR TITLE
feat: expose _last_indexed_block as query

### DIFF
--- a/src/checkpoint/checkpoint.ts
+++ b/src/checkpoint/checkpoint.ts
@@ -73,7 +73,8 @@ export default class Checkpoint {
     return getGraphQL(querySchema, {
       log: this.log.child({ component: 'resolver' }),
       mysql: this.mysql,
-      checkpointsStore: this.store
+      checkpointsStore: this.store,
+      starknetProvider: this.provider
     });
   }
 

--- a/src/checkpoint/checkpoint.ts
+++ b/src/checkpoint/checkpoint.ts
@@ -3,12 +3,14 @@ import { starknetKeccak } from 'starknet/utils/hash';
 import { validateAndParseAddress } from 'starknet/utils/address';
 import Promise from 'bluebird';
 import getGraphQL from './graphql';
-import { GqlEntityController } from './graphql/controller';
+import { GqlEntityController } from './graphql/controllers/entity';
 import { createLogger, Logger, LogLevel } from './utils/logger';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
 import { CheckpointConfig, CheckpointOptions, SupportedNetworkName } from './types';
 import { getContractsFromConfig } from './utils/checkpoint';
-import { CheckpointRecord, CheckpointsStore } from './stores/checkpoints';
+import { CheckpointRecord, CheckpointsStore, MetadataId } from './stores/checkpoints';
+import { GraphQLFieldConfigMap, GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
+import { GqlCheckpointController } from './graphql/controllers/checkpoint';
 
 export default class Checkpoint {
   public config: CheckpointConfig;
@@ -17,6 +19,7 @@ export default class Checkpoint {
   public provider: Provider;
 
   private readonly entityController: GqlEntityController;
+  private readonly checkpointController: GqlCheckpointController;
   private readonly log: Logger;
   private readonly sourceContracts: string[];
 
@@ -30,6 +33,7 @@ export default class Checkpoint {
     this.writer = writer;
     this.schema = schema;
     this.entityController = new GqlEntityController(schema);
+    this.checkpointController = new GqlCheckpointController();
     this.provider = new Provider({ network: this.config.network as SupportedNetworkName });
     this.sourceContracts = getContractsFromConfig(config);
     this.cpBlocksCache = [];
@@ -55,9 +59,21 @@ export default class Checkpoint {
    *
    */
   public get graphql() {
-    return getGraphQL(this.entityController.createEntityQuerySchema(), {
+    const entityQueryFields = this.entityController.generateQueryFields();
+    const coreQueryFields = this.checkpointController.generateQueryFields();
+
+    const querySchema = new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        ...entityQueryFields,
+        ...coreQueryFields
+      }
+    });
+
+    return getGraphQL(querySchema, {
       log: this.log.child({ component: 'resolver' }),
-      mysql: this.mysql
+      mysql: this.mysql,
+      checkpointsStore: this.store
     });
   }
 
@@ -92,7 +108,7 @@ export default class Checkpoint {
     this.log.debug('reset');
 
     await this.store.createStore();
-    await this.store.setMetadata('last_indexed_block', 0);
+    await this.store.setMetadata(MetadataId.LastIndexedBlock, 0);
 
     await this.entityController.createEntityStores(this.mysql);
   }
@@ -124,7 +140,7 @@ export default class Checkpoint {
 
   private async getStartBlockNum() {
     let start = 0;
-    let lastBlock = await this.store.getMetadataNumber('last_indexed_block');
+    let lastBlock = await this.store.getMetadataNumber(MetadataId.LastIndexedBlock);
     lastBlock = lastBlock ?? 0;
 
     const nextBlock = lastBlock + 1;
@@ -157,7 +173,7 @@ export default class Checkpoint {
 
     await this.handleBlock(block);
 
-    await this.store.setMetadata('last_indexed_block', block.block_number);
+    await this.store.setMetadata(MetadataId.LastIndexedBlock, block.block_number);
 
     return this.next(blockNum + 1);
   }

--- a/src/checkpoint/checkpoint.ts
+++ b/src/checkpoint/checkpoint.ts
@@ -151,8 +151,6 @@ export default class Checkpoint {
     return nextBlock > start ? nextBlock : start;
   }
 
-  private async getNextBlockNumber(blockNumber: number) {}
-
   private async next(blockNum: number) {
     const checkpointBlock = await this.getNextCheckpointBlock(blockNum);
     if (checkpointBlock) {

--- a/src/checkpoint/graphql/controllers/checkpoint.ts
+++ b/src/checkpoint/graphql/controllers/checkpoint.ts
@@ -1,5 +1,5 @@
 import { GraphQLField, GraphQLFieldConfig, GraphQLFieldConfigMap, GraphQLInt } from 'graphql';
-import { queryLastIndexedBlock, ResolverContext } from '../resolvers';
+import { queryLastIndexedBlock, queryLatestStarknetBlock, ResolverContext } from '../resolvers';
 
 /**
  * Controller for generating query and mutation schemas relating
@@ -17,7 +17,8 @@ export class GqlCheckpointController {
    */
   public generateQueryFields(): GraphQLFieldConfigMap<any, ResolverContext> {
     return {
-      _last_indexed_block: this.lastIndexedBlockField()
+      _last_indexed_block: this.lastIndexedBlockField(),
+      _latest_starknet_block: this.latestStarknetBlockField()
     };
   }
 
@@ -26,6 +27,16 @@ export class GqlCheckpointController {
       type: GraphQLInt,
       description: 'Fetch the last block Checkpoint has processed.',
       resolve: queryLastIndexedBlock
+    };
+  }
+
+  private latestStarknetBlockField(): GraphQLFieldConfig<any, ResolverContext> {
+    return {
+      type: GraphQLInt,
+      description: `Fetch the latest block number on Starknet.
+        Useful for comparing how far behind this Checkpoint's _last_indexed_block is behind the latest block. 
+      NOTE: Querying this field can be quite slow.`,
+      resolve: queryLatestStarknetBlock
     };
   }
 }

--- a/src/checkpoint/graphql/controllers/checkpoint.ts
+++ b/src/checkpoint/graphql/controllers/checkpoint.ts
@@ -1,0 +1,31 @@
+import { GraphQLField, GraphQLFieldConfig, GraphQLFieldConfigMap, GraphQLInt } from 'graphql';
+import { queryLastIndexedBlock, ResolverContext } from '../resolvers';
+
+/**
+ * Controller for generating query and mutation schemas relating
+ * to core checkpoints data.
+ *
+ */
+export class GqlCheckpointController {
+  /**
+   * This generate graphql Query fields required to introspect
+   * how Checkpoint is performing.
+   *
+   * Fields exposed are prefixed with an underscore, so they are
+   * distinguishable from the Entity Queries.
+   *
+   */
+  public generateQueryFields(): GraphQLFieldConfigMap<any, ResolverContext> {
+    return {
+      _last_indexed_block: this.lastIndexedBlockField()
+    };
+  }
+
+  private lastIndexedBlockField(): GraphQLFieldConfig<any, ResolverContext> {
+    return {
+      type: GraphQLInt,
+      description: 'Fetch the last block Checkpoint has processed.',
+      resolve: queryLastIndexedBlock
+    };
+  }
+}

--- a/src/checkpoint/graphql/controllers/entity.ts
+++ b/src/checkpoint/graphql/controllers/entity.ts
@@ -18,9 +18,9 @@ import {
   GraphQLString,
   Source
 } from 'graphql';
-import { AsyncMySqlPool } from '../mysql';
+import { AsyncMySqlPool } from '../../mysql';
 
-import { querySingle, queryMulti, ResolverContext } from './resolvers';
+import { querySingle, queryMulti, ResolverContext } from '../resolvers';
 
 /**
  * Type for single and multiple query resolvers
@@ -83,12 +83,12 @@ export class GqlEntityController {
    * ```
    *
    */
-  public createEntityQuerySchema(
+  public generateQueryFields(
     resolvers: EntityQueryResolvers = {
       singleEntityResolver: querySingle,
       multipleEntityResolver: queryMulti
     }
-  ): GraphQLObjectType {
+  ): GraphQLFieldConfigMap<any, any> {
     const queryFields: GraphQLFieldConfigMap<any, any> = {};
 
     this.schemaObjects.forEach(type => {
@@ -102,10 +102,7 @@ export class GqlEntityController {
       );
     });
 
-    return new GraphQLObjectType({
-      name: 'Query',
-      fields: queryFields
-    });
+    return queryFields;
   }
 
   /**

--- a/src/checkpoint/graphql/resolvers.ts
+++ b/src/checkpoint/graphql/resolvers.ts
@@ -1,4 +1,5 @@
 import { AsyncMySqlPool } from '../mysql';
+import { CheckpointsStore, MetadataId } from '../stores/checkpoints';
 import { Logger } from '../utils/logger';
 
 /**
@@ -7,6 +8,7 @@ import { Logger } from '../utils/logger';
 export interface ResolverContext {
   log: Logger;
   mysql: AsyncMySqlPool;
+  checkpointsStore: CheckpointsStore;
 }
 
 export async function queryMulti(parent, args, context: ResolverContext, info) {
@@ -40,4 +42,8 @@ export async function querySingle(parent, args, context: ResolverContext, info) 
 
   const [item] = await mysql.queryAsync(query, [args.id]);
   return item;
+}
+
+export async function queryLastIndexedBlock(_parent, _args, ctx: ResolverContext) {
+  return ctx.checkpointsStore.getMetadataNumber(MetadataId.LastIndexedBlock);
 }

--- a/src/checkpoint/graphql/resolvers.ts
+++ b/src/checkpoint/graphql/resolvers.ts
@@ -1,3 +1,4 @@
+import { Provider } from 'starknet';
 import { AsyncMySqlPool } from '../mysql';
 import { CheckpointsStore, MetadataId } from '../stores/checkpoints';
 import { Logger } from '../utils/logger';
@@ -9,6 +10,7 @@ export interface ResolverContext {
   log: Logger;
   mysql: AsyncMySqlPool;
   checkpointsStore: CheckpointsStore;
+  starknetProvider: Provider;
 }
 
 export async function queryMulti(parent, args, context: ResolverContext, info) {
@@ -46,4 +48,12 @@ export async function querySingle(parent, args, context: ResolverContext, info) 
 
 export async function queryLastIndexedBlock(_parent, _args, ctx: ResolverContext) {
   return ctx.checkpointsStore.getMetadataNumber(MetadataId.LastIndexedBlock);
+}
+
+// returns the latest starknet block visible to this node.
+export async function queryLatestStarknetBlock(_parent, _args, ctx: ResolverContext) {
+  // this might need some rate limiting to avoid being abused
+  // because it is quite slow.
+  const latestBlock = await ctx.starknetProvider.getBlock();
+  return latestBlock.block_number;
 }

--- a/src/checkpoint/stores/checkpoints.ts
+++ b/src/checkpoint/stores/checkpoints.ts
@@ -27,6 +27,14 @@ export interface CheckpointRecord {
 }
 
 /**
+ * Metadata Ids stored in the CheckpointStore.
+ *
+ */
+export enum MetadataId {
+  LastIndexedBlock = 'last_indexed_block'
+}
+
+/**
  * Checkpoints store is a data store class for managing
  * checkpoints data schema and records.
  *

--- a/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
@@ -10,6 +10,13 @@ exports[`GqlCheckpointController generateQueryFields should work 1`] = `
 "type Query {
   \\"\\"\\"Fetch the last block Checkpoint has processed.\\"\\"\\"
   _last_indexed_block: Int
+
+  \\"\\"\\"
+  Fetch the latest block number on Starknet.
+          Useful for comparing how far behind this Checkpoint's _last_indexed_block is behind the latest block. 
+        NOTE: Querying this field can be quite slow.
+  \\"\\"\\"
+  _latest_starknet_block: Int
 }"
 `;
 

--- a/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
@@ -6,26 +6,10 @@ exports[` 2`] = `"'id' field for type Vote is not a scalar type."`;
 
 exports[` 3`] = `"'id' field for type Participant is not a scalar type."`;
 
-exports[`GqlEntityController createEntityQuerySchema should work 1`] = `
+exports[`GqlCheckpointController generateQueryFields should work 1`] = `
 "type Query {
-  vote(id: Int!): Vote
-  votes(first: Int, skip: Int, orderBy: String, orderDirection: String, where: WhereVote): [Vote]
-}
-
-type Vote {
-  id: Int!
-  name: String
-}
-
-input WhereVote {
-  id_gt: Int
-  id_gte: Int
-  id_lt: Int
-  id_lte: Int
-  id: Int
-  id_in: [Int]
-  name: String
-  name_in: [String]
+  \\"\\"\\"Fetch the last block Checkpoint has processed.\\"\\"\\"
+  _last_indexed_block: Int
 }"
 `;
 
@@ -52,4 +36,27 @@ CREATE TABLE votes (
     },
   ],
 }
+`;
+
+exports[`GqlEntityController generateQueryFields should work 1`] = `
+"type Query {
+  vote(id: Int!): Vote
+  votes(first: Int, skip: Int, orderBy: String, orderDirection: String, where: WhereVote): [Vote]
+}
+
+type Vote {
+  id: Int!
+  name: String
+}
+
+input WhereVote {
+  id_gt: Int
+  id_gte: Int
+  id_lt: Int
+  id_lte: Int
+  id: Int
+  id_in: [Int]
+  name: String
+  name_in: [String]
+}"
 `;


### PR DESCRIPTION
This exposes the last indexed block as a core graphql Query. It adopts a convention where non-entity queries would be prefixed with an `_`.

Aside from the `_last_indexed_block` query fields, this also implements a `_latest_starknet_block` query field to fetch latest starknet block and help can be useful to monitor how far behind this Checkpoint instance is lagging.

It also includes a minor refactoring that moves metadata keys to an enum, to prevent possible errors from using raw strings.

It resolves #37 