### PR TITLE
feat: expose _checkpoints query

### DIFF
--- a/src/checkpoint/graphql/controllers/checkpoint.ts
+++ b/src/checkpoint/graphql/controllers/checkpoint.ts
@@ -1,5 +1,17 @@
-import { GraphQLField, GraphQLFieldConfig, GraphQLFieldConfigMap, GraphQLInt } from 'graphql';
-import { queryLastIndexedBlock, queryLatestStarknetBlock, ResolverContext } from '../resolvers';
+import {
+  GraphQLFieldConfig,
+  GraphQLFieldConfigMap,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString
+} from 'graphql';
+import {
+  queryCheckpoints,
+  queryLastIndexedBlock,
+  queryLatestStarknetBlock,
+  ResolverContext
+} from '../resolvers';
 
 /**
  * Controller for generating query and mutation schemas relating
@@ -18,7 +30,8 @@ export class GqlCheckpointController {
   public generateQueryFields(): GraphQLFieldConfigMap<any, ResolverContext> {
     return {
       _last_indexed_block: this.lastIndexedBlockField(),
-      _latest_starknet_block: this.latestStarknetBlockField()
+      _latest_starknet_block: this.latestStarknetBlockField(),
+      _checkpoints: this.checkpointsField()
     };
   }
 
@@ -37,6 +50,29 @@ export class GqlCheckpointController {
         Useful for comparing how far behind this Checkpoint's _last_indexed_block is behind the latest block. 
       NOTE: Querying this field can be quite slow.`,
       resolve: queryLatestStarknetBlock
+    };
+  }
+
+  private checkpointsField(): GraphQLFieldConfig<any, ResolverContext> {
+    return {
+      type: new GraphQLList(GraphQLInt),
+      description: 'Fetch starknet blocks (checkpoints) where a contracts interaction exists.',
+      args: {
+        contract: {
+          type: new GraphQLNonNull(GraphQLString),
+          description: 'contract address to fetch checkpoint blocks'
+        },
+        fromBlock: {
+          type: GraphQLInt,
+          description: 'filter result starting from this block'
+        },
+        size: {
+          type: GraphQLInt,
+          description:
+            'maximum size of blocks to return in results. defaults to 100. Max possible value is 1000.'
+        }
+      },
+      resolve: queryCheckpoints
     };
   }
 }

--- a/src/checkpoint/graphql/resolvers.ts
+++ b/src/checkpoint/graphql/resolvers.ts
@@ -57,3 +57,21 @@ export async function queryLatestStarknetBlock(_parent, _args, ctx: ResolverCont
   const latestBlock = await ctx.starknetProvider.getBlock();
   return latestBlock.block_number;
 }
+
+const MaxCheckpointQuerySize = 1000;
+export async function queryCheckpoints(_parent, args, ctx: ResolverContext) {
+  const fromBlock = args.fromBlock || 0;
+  const contracts = [args.contract];
+  const size = args.size || 100;
+
+  if (size > MaxCheckpointQuerySize) {
+    throw new Error(`query 'size' exceeds max value. max value is ${MaxCheckpointQuerySize}`);
+  }
+
+  const checkpoints = await ctx.checkpointsStore.getNextCheckpointBlocks(
+    fromBlock,
+    contracts,
+    size
+  );
+  return checkpoints;
+}

--- a/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
@@ -17,6 +17,22 @@ exports[`GqlCheckpointController generateQueryFields should work 1`] = `
         NOTE: Querying this field can be quite slow.
   \\"\\"\\"
   _latest_starknet_block: Int
+
+  \\"\\"\\"
+  Fetch starknet blocks (checkpoints) where a contracts interaction exists.
+  \\"\\"\\"
+  _checkpoints(
+    \\"\\"\\"contract address to fetch checkpoint blocks\\"\\"\\"
+    contract: String!
+
+    \\"\\"\\"filter result starting from this block\\"\\"\\"
+    fromBlock: Int
+
+    \\"\\"\\"
+    maximum size of blocks to return in results. defaults to 100. Max possible value is 1000.
+    \\"\\"\\"
+    size: Int
+  ): [Int]
 }"
 `;
 

--- a/test/unit/checkpoint/graphql/__snapshots__/resolvers.test.ts.snap
+++ b/test/unit/checkpoint/graphql/__snapshots__/resolvers.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`queryCheckpoints should throw if size exceeds allowed max block 1`] = `"query 'size' exceeds max value. max value is 1000"`;
+
+exports[`queryCheckpoints should work with appropriate defaults 1`] = `
+Array [
+  Array [
+    0,
+    Array [
+      "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
+    ],
+    100,
+  ],
+]
+`;
+
+exports[`queryCheckpoints should work with custom block arguments 1`] = `
+Array [
+  Array [
+    5100,
+    Array [
+      "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
+    ],
+    500,
+  ],
+]
+`;

--- a/test/unit/checkpoint/graphql/resolvers.test.ts
+++ b/test/unit/checkpoint/graphql/resolvers.test.ts
@@ -1,0 +1,42 @@
+import { DeepMockProxy, mock, mockDeep } from 'jest-mock-extended';
+import { queryCheckpoints, ResolverContext } from '../../../../src/checkpoint/graphql/resolvers';
+import { CheckpointsStore } from '../../../../src/checkpoint/stores/checkpoints';
+
+describe('queryCheckpoints', () => {
+  let ctx: DeepMockProxy<ResolverContext> & ResolverContext;
+
+  beforeEach(() => {
+    ctx = mockDeep<ResolverContext>();
+  });
+
+  it('should work with appropriate defaults', async () => {
+    const args = {
+      contract: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3'
+    };
+
+    await queryCheckpoints({}, args, ctx);
+
+    expect(ctx.checkpointsStore.getNextCheckpointBlocks.mock.calls).toMatchSnapshot();
+  });
+
+  it('should work with custom block arguments', async () => {
+    const args = {
+      contract: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
+      fromBlock: 5100,
+      size: 500
+    };
+
+    await queryCheckpoints({}, args, ctx);
+
+    expect(ctx.checkpointsStore.getNextCheckpointBlocks.mock.calls).toMatchSnapshot();
+  });
+
+  it('should throw if size exceeds allowed max block', async () => {
+    const args = {
+      contract: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
+      size: 500000
+    };
+
+    await expect(queryCheckpoints({}, args, ctx)).rejects.toThrowErrorMatchingSnapshot();
+  });
+});


### PR DESCRIPTION
> NOTE: Please review #51 first, before reviewing this PR, because this changes is based off that PR's branch.

This implements the logic to expose a `_checkpoints` query that allows
users to fetch list of blocks in the Checkpoint database that have
interacted with a contract.

This will be useful to monitor if checkpoint has enough blocks in its database to speedup sync or will have to run through each block. (And can eventually be useful for syncing checkpoints between multiple instances of Checkpoint).

<img width="1079" alt="Screenshot 2022-05-02 at 8 03 02 pm" src="https://user-images.githubusercontent.com/3120013/166312694-1f34ef53-79b1-4369-bb41-0cd28aa79074.png">

Resolve #40 