### PR TITLE
feat: expose _metadata graphql queries

### DIFF
--- a/src/checkpoint/checkpoint.ts
+++ b/src/checkpoint/checkpoint.ts
@@ -2,7 +2,7 @@ import { GetBlockResponse, Provider } from 'starknet';
 import { starknetKeccak } from 'starknet/utils/hash';
 import { validateAndParseAddress } from 'starknet/utils/address';
 import Promise from 'bluebird';
-import getGraphQL, { MetadataGraphQLObject } from './graphql';
+import getGraphQL, { CheckpointsGraphQLObject, MetadataGraphQLObject } from './graphql';
 import { GqlEntityController } from './graphql/controller';
 import { createLogger, Logger, LogLevel } from './utils/logger';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
@@ -57,7 +57,10 @@ export default class Checkpoint {
    */
   public get graphql() {
     const entityQueryFields = this.entityController.generateQueryFields();
-    const coreQueryFields = this.entityController.generateQueryFields([MetadataGraphQLObject]);
+    const coreQueryFields = this.entityController.generateQueryFields([
+      MetadataGraphQLObject,
+      CheckpointsGraphQLObject
+    ]);
 
     const querySchema = new GraphQLObjectType({
       name: 'Query',

--- a/src/checkpoint/checkpoint.ts
+++ b/src/checkpoint/checkpoint.ts
@@ -8,7 +8,7 @@ import { createLogger, Logger, LogLevel } from './utils/logger';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
 import { CheckpointConfig, CheckpointOptions, SupportedNetworkName } from './types';
 import { getContractsFromConfig } from './utils/checkpoint';
-import { CheckpointRecord, CheckpointsStore } from './stores/checkpoints';
+import { CheckpointRecord, CheckpointsStore, MetadataId } from './stores/checkpoints';
 import { GraphQLObjectType } from 'graphql';
 
 export default class Checkpoint {
@@ -104,7 +104,7 @@ export default class Checkpoint {
     this.log.debug('reset');
 
     await this.store.createStore();
-    await this.store.setMetadata('last_indexed_block', 0);
+    await this.store.setMetadata(MetadataId.LastIndexedBlock, 0);
 
     await this.entityController.createEntityStores(this.mysql);
   }
@@ -136,7 +136,7 @@ export default class Checkpoint {
 
   private async getStartBlockNum() {
     let start = 0;
-    let lastBlock = await this.store.getMetadataNumber('last_indexed_block');
+    let lastBlock = await this.store.getMetadataNumber(MetadataId.LastIndexedBlock);
     lastBlock = lastBlock ?? 0;
 
     const nextBlock = lastBlock + 1;
@@ -169,7 +169,7 @@ export default class Checkpoint {
 
     await this.handleBlock(block);
 
-    await this.store.setMetadata('last_indexed_block', block.block_number);
+    await this.store.setMetadata(MetadataId.LastIndexedBlock, block.block_number);
 
     return this.next(blockNum + 1);
   }

--- a/src/checkpoint/graphql/controller.ts
+++ b/src/checkpoint/graphql/controller.ts
@@ -1,5 +1,6 @@
 import {
   buildSchema,
+  GraphQLEnumType,
   GraphQLField,
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
@@ -29,6 +30,14 @@ interface EntityQueryResolvers<Context = ResolverContext> {
   singleEntityResolver: GraphQLFieldResolver<unknown, Context>;
   multipleEntityResolver: GraphQLFieldResolver<unknown, Context>;
 }
+
+const GraphQLOrderDirection = new GraphQLEnumType({
+  name: 'OrderDirection',
+  values: {
+    asc: { value: 'ASC' },
+    desc: { value: 'DESC' }
+  }
+});
 
 /**
  * Controller for performing actions based on the graphql schema provided to its
@@ -251,7 +260,7 @@ export class GqlEntityController {
           type: GraphQLString
         },
         orderDirection: {
-          type: GraphQLString
+          type: GraphQLOrderDirection
         },
         where: { type: new GraphQLInputObjectType(whereInputConfig) }
       },

--- a/src/checkpoint/graphql/controller.ts
+++ b/src/checkpoint/graphql/controller.ts
@@ -83,15 +83,18 @@ export class GqlEntityController {
    * ```
    *
    */
-  public createEntityQuerySchema(
+  public generateQueryFields(
+    schemaObjects?: GraphQLObjectType[],
     resolvers: EntityQueryResolvers = {
       singleEntityResolver: querySingle,
       multipleEntityResolver: queryMulti
     }
-  ): GraphQLObjectType {
+  ): GraphQLFieldConfigMap<any, any> {
+    schemaObjects = schemaObjects || this.schemaObjects;
+
     const queryFields: GraphQLFieldConfigMap<any, any> = {};
 
-    this.schemaObjects.forEach(type => {
+    schemaObjects.forEach(type => {
       queryFields[type.name.toLowerCase()] = this.getSingleEntityQueryConfig(
         type,
         resolvers.singleEntityResolver
@@ -102,10 +105,7 @@ export class GqlEntityController {
       );
     });
 
-    return new GraphQLObjectType({
-      name: 'Query',
-      fields: queryFields
-    });
+    return queryFields;
   }
 
   /**
@@ -166,6 +166,8 @@ export class GqlEntityController {
     // TODO(perfectmak): wrap this in a transaction
     return mysql.queryAsync(sql.trimEnd());
   }
+
+  public static generateQueryFields() {}
 
   /**
    * Returns a list of objects defined within the graphql typedefs.

--- a/src/checkpoint/graphql/index.ts
+++ b/src/checkpoint/graphql/index.ts
@@ -1,5 +1,11 @@
 import { graphqlHTTP } from 'express-graphql';
-import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import {
+  GraphQLID,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString
+} from 'graphql';
 import { ResolverContext } from './resolvers';
 
 /**
@@ -10,3 +16,17 @@ export default function get(query: GraphQLObjectType, context: ResolverContext) 
   const schema = new GraphQLSchema({ query });
   return graphqlHTTP({ schema, context, graphiql: {} });
 }
+
+/**
+ * This objects name and field maps to the values of the _metadata
+ * database store
+ *
+ */
+export const MetadataGraphQLObject = new GraphQLObjectType({
+  name: '_Metadata',
+  description: 'Core metadata values used internally by Checkpoint',
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLID), description: 'example: last_indexed_block' },
+    value: { type: GraphQLString }
+  }
+});

--- a/src/checkpoint/graphql/index.ts
+++ b/src/checkpoint/graphql/index.ts
@@ -1,6 +1,7 @@
 import { graphqlHTTP } from 'express-graphql';
 import {
   GraphQLID,
+  GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLSchema,
@@ -28,5 +29,27 @@ export const MetadataGraphQLObject = new GraphQLObjectType({
   fields: {
     id: { type: new GraphQLNonNull(GraphQLID), description: 'example: last_indexed_block' },
     value: { type: GraphQLString }
+  }
+});
+
+/**
+ * This objects name and field maps to the values of the _checkpoints
+ * database store. And is used to generate entity queries for graphql
+ *
+ */
+export const CheckpointsGraphQLObject = new GraphQLObjectType({
+  name: '_Checkpoint',
+  description: 'Contract and Block where its event is found.',
+  fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'id computed as last 5 bytes of sha256(contract+block)'
+    },
+    block_number: {
+      type: new GraphQLNonNull(GraphQLInt)
+    },
+    contract_address: {
+      type: new GraphQLNonNull(GraphQLString)
+    }
   }
 });

--- a/src/checkpoint/graphql/resolvers.ts
+++ b/src/checkpoint/graphql/resolvers.ts
@@ -22,11 +22,15 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
   }
   const first = args?.first || 1000;
   const skip = args?.skip || 0;
-  const orderBy = 'created';
-  const orderDirection = 'DESC';
+
+  let orderBySql = '';
+  if (args.orderBy) {
+    orderBySql = `ORDER BY ${args.orderBy} ${args.orderDirection || 'DESC'}`;
+  }
+
   params.push(skip, first);
 
-  const query = `SELECT * FROM ${info.fieldName} ${whereSql} ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?`;
+  const query = `SELECT * FROM ${info.fieldName} ${whereSql} ${orderBySql} LIMIT ?, ?`;
   log.debug({ sql: query, args }, 'executing multi query');
 
   return await mysql.queryAsync(query, params);

--- a/src/checkpoint/graphql/resolvers.ts
+++ b/src/checkpoint/graphql/resolvers.ts
@@ -9,14 +9,6 @@ export interface ResolverContext {
   mysql: AsyncMySqlPool;
 }
 
-const getTableName = (fieldName: string): string => {
-  if (fieldName.startsWith('_')) {
-    return fieldName;
-  }
-
-  return `${fieldName}s`;
-};
-
 export async function queryMulti(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
 
@@ -34,9 +26,7 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
   const orderDirection = 'DESC';
   params.push(skip, first);
 
-  const query = `SELECT * FROM ${getTableName(
-    info.fieldName
-  )} ${whereSql} ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?`;
+  const query = `SELECT * FROM ${info.fieldName} ${whereSql} ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?`;
   log.debug({ sql: query, args }, 'executing multi query');
 
   return await mysql.queryAsync(query, params);
@@ -45,7 +35,7 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
 export async function querySingle(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
 
-  const query = `SELECT * FROM ${getTableName(info.fieldName)} WHERE id = ? LIMIT 1`;
+  const query = `SELECT * FROM ${info.fieldName}s WHERE id = ? LIMIT 1`;
   log.debug({ sql: query, args }, 'executing single query');
 
   const [item] = await mysql.queryAsync(query, [args.id]);

--- a/src/checkpoint/graphql/resolvers.ts
+++ b/src/checkpoint/graphql/resolvers.ts
@@ -9,6 +9,14 @@ export interface ResolverContext {
   mysql: AsyncMySqlPool;
 }
 
+const getTableName = (fieldName: string): string => {
+  if (fieldName.startsWith('_')) {
+    return fieldName;
+  }
+
+  return `${fieldName}s`;
+};
+
 export async function queryMulti(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
 
@@ -26,7 +34,9 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
   const orderDirection = 'DESC';
   params.push(skip, first);
 
-  const query = `SELECT * FROM ${info.fieldName} ${whereSql} ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?`;
+  const query = `SELECT * FROM ${getTableName(
+    info.fieldName
+  )} ${whereSql} ORDER BY ${orderBy} ${orderDirection} LIMIT ?, ?`;
   log.debug({ sql: query, args }, 'executing multi query');
 
   return await mysql.queryAsync(query, params);
@@ -35,7 +45,7 @@ export async function queryMulti(parent, args, context: ResolverContext, info) {
 export async function querySingle(parent, args, context: ResolverContext, info) {
   const { log, mysql } = context;
 
-  const query = `SELECT * FROM ${info.fieldName}s WHERE id = ? LIMIT 1`;
+  const query = `SELECT * FROM ${getTableName(info.fieldName)} WHERE id = ? LIMIT 1`;
   log.debug({ sql: query, args }, 'executing single query');
 
   const [item] = await mysql.queryAsync(query, [args.id]);

--- a/src/checkpoint/stores/checkpoints.ts
+++ b/src/checkpoint/stores/checkpoints.ts
@@ -3,7 +3,7 @@ import { Logger } from '../utils/logger';
 
 const Table = {
   Checkpoints: '_checkpoints',
-  Metadata: '_metadata'
+  Metadata: '_metadatas' // using plural names to confirm with standards entities
 };
 
 const Fields = {

--- a/src/checkpoint/stores/checkpoints.ts
+++ b/src/checkpoint/stores/checkpoints.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import { AsyncMySqlPool } from '../mysql';
 import { Logger } from '../utils/logger';
 
@@ -8,6 +9,7 @@ const Table = {
 
 const Fields = {
   Checkpoints: {
+    Id: 'id',
     BlockNumber: 'block_number',
     ContractAddress: 'contract_address'
   },
@@ -34,6 +36,18 @@ export enum MetadataId {
   LastIndexedBlock = 'last_indexed_block'
 }
 
+const CheckpointIdSize = 10;
+
+/**
+ * Generates a unique hex based on the contract address and block number.
+ * Used when as id for storing checkpoints records.
+ *
+ */
+export const getCheckpointId = (contract: string, block: number): string => {
+  const data = `${contract}${block}`;
+  return crypto.createHash('sha256').update(data).digest('hex').slice(-CheckpointIdSize);
+};
+
 /**
  * Checkpoints store is a data store class for managing
  * checkpoints data schema and records.
@@ -56,9 +70,10 @@ export class CheckpointsStore {
     this.log.debug('creating checkpoints tables...');
 
     let sql = `CREATE TABLE IF NOT EXISTS ${Table.Checkpoints} (
+      ${Fields.Checkpoints.Id} VARCHAR(${CheckpointIdSize}) NOT NULL,
       ${Fields.Checkpoints.BlockNumber} BIGINT NOT NULL,
       ${Fields.Checkpoints.ContractAddress} VARCHAR(66) NOT NULL,
-      PRIMARY KEY (${Fields.Checkpoints.BlockNumber}, ${Fields.Checkpoints.ContractAddress})
+      PRIMARY KEY (${Fields.Checkpoints.Id})
     );`;
 
     sql += `\nCREATE TABLE IF NOT EXISTS ${Table.Metadata} (
@@ -106,7 +121,8 @@ export class CheckpointsStore {
     }
     await this.mysql.queryAsync(`INSERT IGNORE INTO ${Table.Checkpoints} VALUES ?`, [
       checkpoints.map(checkpoint => {
-        return [checkpoint.blockNumber, checkpoint.contractAddress];
+        const id = getCheckpointId(checkpoint.contractAddress, checkpoint.blockNumber);
+        return [id, checkpoint.blockNumber, checkpoint.contractAddress];
       })
     ]);
   }

--- a/src/checkpoint/stores/checkpoints.ts
+++ b/src/checkpoint/stores/checkpoints.ts
@@ -27,6 +27,14 @@ export interface CheckpointRecord {
 }
 
 /**
+ * Metadata Ids stored in the CheckpointStore.
+ *
+ */
+export enum MetadataId {
+  LastIndexedBlock = 'last_indexed_block'
+}
+
+/**
  * Checkpoints store is a data store class for managing
  * checkpoints data schema and records.
  *

--- a/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
@@ -6,29 +6,6 @@ exports[` 2`] = `"'id' field for type Vote is not a scalar type."`;
 
 exports[` 3`] = `"'id' field for type Participant is not a scalar type."`;
 
-exports[`GqlEntityController createEntityQuerySchema should work 1`] = `
-"type Query {
-  vote(id: Int!): Vote
-  votes(first: Int, skip: Int, orderBy: String, orderDirection: String, where: WhereVote): [Vote]
-}
-
-type Vote {
-  id: Int!
-  name: String
-}
-
-input WhereVote {
-  id_gt: Int
-  id_gte: Int
-  id_lt: Int
-  id_lte: Int
-  id: Int
-  id_in: [Int]
-  name: String
-  name_in: [String]
-}"
-`;
-
 exports[`GqlEntityController createEntityStores should work 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -52,4 +29,27 @@ CREATE TABLE votes (
     },
   ],
 }
+`;
+
+exports[`GqlEntityController generateQueryFields should work 1`] = `
+"type Query {
+  vote(id: Int!): Vote
+  votes(first: Int, skip: Int, orderBy: String, orderDirection: String, where: WhereVote): [Vote]
+}
+
+type Vote {
+  id: Int!
+  name: String
+}
+
+input WhereVote {
+  id_gt: Int
+  id_gte: Int
+  id_lt: Int
+  id_lte: Int
+  id: Int
+  id_in: [Int]
+  name: String
+  name_in: [String]
+}"
 `;

--- a/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
+++ b/test/unit/checkpoint/graphql/__snapshots__/controller.test.ts.snap
@@ -34,12 +34,17 @@ CREATE TABLE votes (
 exports[`GqlEntityController generateQueryFields should work 1`] = `
 "type Query {
   vote(id: Int!): Vote
-  votes(first: Int, skip: Int, orderBy: String, orderDirection: String, where: WhereVote): [Vote]
+  votes(first: Int, skip: Int, orderBy: String, orderDirection: OrderDirection, where: WhereVote): [Vote]
 }
 
 type Vote {
   id: Int!
   name: String
+}
+
+enum OrderDirection {
+  asc
+  desc
 }
 
 input WhereVote {

--- a/test/unit/checkpoint/graphql/controller.test.ts
+++ b/test/unit/checkpoint/graphql/controller.test.ts
@@ -1,10 +1,10 @@
-import { GraphQLSchema, printSchema } from 'graphql';
+import { GraphQLObjectType, GraphQLSchema, printSchema } from 'graphql';
 import { mock } from 'jest-mock-extended';
 import { GqlEntityController } from '../../../../src/checkpoint/graphql/controller';
 import { AsyncMySqlPool } from '../../../../src/checkpoint/mysql';
 
 describe('GqlEntityController', () => {
-  describe('createEntityQuerySchema', () => {
+  describe('generateQueryFields', () => {
     it('should work', () => {
       const controller = new GqlEntityController(`
 type Vote {
@@ -12,7 +12,11 @@ type Vote {
   name: String
 }
   `);
-      const querySchema = controller.createEntityQuerySchema();
+      const queryFields = controller.generateQueryFields();
+      const querySchema = new GraphQLObjectType({
+        name: 'Query',
+        fields: queryFields
+      });
 
       const schema = printSchema(new GraphQLSchema({ query: querySchema }));
       expect(schema).toMatchSnapshot();
@@ -34,7 +38,7 @@ type Vote {
       }
     ])('should fail for $reason', ({ schema }) => {
       const controller = new GqlEntityController(schema);
-      expect(() => controller.createEntityQuerySchema()).toThrowErrorMatchingSnapshot();
+      expect(() => controller.generateQueryFields()).toThrowErrorMatchingSnapshot();
     });
   });
 

--- a/test/unit/checkpoint/stores/__snapshots__/checkpoints.test.ts.snap
+++ b/test/unit/checkpoint/stores/__snapshots__/checkpoints.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckpointsStore createStore should execute correct query 1`] = `
+Array [
+  Array [
+    "CREATE TABLE IF NOT EXISTS _checkpoints (
+      id VARCHAR(10) NOT NULL,
+      block_number BIGINT NOT NULL,
+      contract_address VARCHAR(66) NOT NULL,
+      PRIMARY KEY (id)
+    );
+CREATE TABLE IF NOT EXISTS _metadatas (
+      id VARCHAR(20) NOT NULL,
+      value VARCHAR(128) NOT NULL,
+      PRIMARY KEY (id)
+    );",
+  ],
+]
+`;
+
+exports[`CheckpointsStore insertCheckpoints should should execute correct query 1`] = `
+Array [
+  Array [
+    "INSERT IGNORE INTO _checkpoints VALUES ?",
+    Array [
+      Array [
+        Array [
+          "a739beda26",
+          5000,
+          "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
+        ],
+        Array [
+          "d2b8dcc2b5",
+          123222,
+          "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
+        ],
+      ],
+    ],
+  ],
+]
+`;

--- a/test/unit/checkpoint/stores/checkpoints.test.ts
+++ b/test/unit/checkpoint/stores/checkpoints.test.ts
@@ -1,0 +1,52 @@
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
+import { AsyncMySqlPool } from '../../../../src/checkpoint';
+import { CheckpointsStore, getCheckpointId } from '../../../../src/checkpoint/stores/checkpoints';
+import { Logger } from '../../../../src/checkpoint/utils/logger';
+
+describe('CheckpointsStore', () => {
+  let store: CheckpointsStore;
+  let mockMysql: AsyncMySqlPool & DeepMockProxy<AsyncMySqlPool>;
+  let logger: Logger & DeepMockProxy<Logger>;
+
+  beforeEach(() => {
+    mockMysql = mockDeep<AsyncMySqlPool>();
+    logger = mockDeep<Logger>({
+      child: () => mockDeep()
+    });
+    store = new CheckpointsStore(mockMysql, logger);
+  });
+
+  describe('createStore', () => {
+    it('should execute correct query', async () => {
+      await store.createStore();
+
+      expect(mockMysql.queryAsync.mock.calls).toMatchSnapshot();
+    });
+  });
+
+  describe('insertCheckpoints', () => {
+    it('should should execute correct query', async () => {
+      const checkpoints = [
+        {
+          contractAddress: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
+          blockNumber: 5000
+        },
+        {
+          contractAddress: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
+          blockNumber: 123222
+        }
+      ];
+      await store.insertCheckpoints(checkpoints);
+
+      expect(mockMysql.queryAsync.mock.calls).toMatchSnapshot();
+
+      // verify id is properly computed
+      const queryParams = mockMysql.queryAsync.mock.calls[0][1];
+      const firstBlockInput = queryParams[0][0];
+
+      expect(firstBlockInput[0]).toEqual(
+        getCheckpointId(checkpoints[0].contractAddress, checkpoints[0].blockNumber)
+      );
+    });
+  });
+});


### PR DESCRIPTION
This exposes the _metadata table as standard entity queries.
Allowing users to query the last_indexed_block metadata value.

Now, user can use the `_metadata` and `_metadatas` queries to fetch values from the _metadata table.

<img width="789" alt="Screenshot 2022-05-04 at 9 47 48 pm" src="https://user-images.githubusercontent.com/3120013/166823469-95f4d397-10be-4799-9e4f-4b632bae6c4d.png">

Resolves #37 