### PR TITLE
feat: expose _checkpoints gql

### DIFF
--- a/src/checkpoint/checkpoint.ts
+++ b/src/checkpoint/checkpoint.ts
@@ -2,7 +2,7 @@ import { GetBlockResponse, Provider } from 'starknet';
 import { starknetKeccak } from 'starknet/utils/hash';
 import { validateAndParseAddress } from 'starknet/utils/address';
 import Promise from 'bluebird';
-import getGraphQL, { MetadataGraphQLObject } from './graphql';
+import getGraphQL, { CheckpointsGraphQLObject, MetadataGraphQLObject } from './graphql';
 import { GqlEntityController } from './graphql/controller';
 import { createLogger, Logger, LogLevel } from './utils/logger';
 import { AsyncMySqlPool, createMySqlPool } from './mysql';
@@ -57,7 +57,10 @@ export default class Checkpoint {
    */
   public get graphql() {
     const entityQueryFields = this.entityController.generateQueryFields();
-    const coreQueryFields = this.entityController.generateQueryFields([MetadataGraphQLObject]);
+    const coreQueryFields = this.entityController.generateQueryFields([
+      MetadataGraphQLObject,
+      CheckpointsGraphQLObject
+    ]);
 
     const querySchema = new GraphQLObjectType({
       name: 'Query',

--- a/src/checkpoint/graphql/index.ts
+++ b/src/checkpoint/graphql/index.ts
@@ -1,6 +1,7 @@
 import { graphqlHTTP } from 'express-graphql';
 import {
   GraphQLID,
+  GraphQLInt,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLSchema,
@@ -28,5 +29,27 @@ export const MetadataGraphQLObject = new GraphQLObjectType({
   fields: {
     id: { type: new GraphQLNonNull(GraphQLID), description: 'example: last_indexed_block' },
     value: { type: GraphQLString }
+  }
+});
+
+/**
+ * This objects name and field maps to the values of the _checkpoints
+ * database store. And is used to generate entity queries for graphql
+ *
+ */
+export const CheckpointsGraphQLObject = new GraphQLObjectType({
+  name: '_Checkpoint',
+  description: 'Contract and Block where its event is found.',
+  fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'id computed as last 5 bytes of sha256(contract+block)'
+    },
+    block_number: {
+      type: new GraphQLNonNull(GraphQLInt)
+    },
+    contract_address: {
+      type: new GraphQLNonNull(GraphQLString)
+    }
   }
 });

--- a/src/checkpoint/stores/checkpoints.ts
+++ b/src/checkpoint/stores/checkpoints.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import { AsyncMySqlPool } from '../mysql';
 import { Logger } from '../utils/logger';
 
@@ -8,6 +9,7 @@ const Table = {
 
 const Fields = {
   Checkpoints: {
+    Id: 'id',
     BlockNumber: 'block_number',
     ContractAddress: 'contract_address'
   },
@@ -34,6 +36,18 @@ export enum MetadataId {
   LastIndexedBlock = 'last_indexed_block'
 }
 
+const CheckpointIdSize = 10;
+
+/**
+ * Generates a unique hex based on the contract address and block number.
+ * Used when as id for storing checkpoints records.
+ *
+ */
+export const getCheckpointId = (contract: string, block: number): string => {
+  const data = `${contract}${block}`;
+  return crypto.createHash('sha256').update(data).digest('hex').slice(-CheckpointIdSize);
+};
+
 /**
  * Checkpoints store is a data store class for managing
  * checkpoints data schema and records.
@@ -56,9 +70,10 @@ export class CheckpointsStore {
     this.log.debug('creating checkpoints tables...');
 
     let sql = `CREATE TABLE IF NOT EXISTS ${Table.Checkpoints} (
+      ${Fields.Checkpoints.Id} VARCHAR(${CheckpointIdSize}) NOT NULL,
       ${Fields.Checkpoints.BlockNumber} BIGINT NOT NULL,
       ${Fields.Checkpoints.ContractAddress} VARCHAR(66) NOT NULL,
-      PRIMARY KEY (${Fields.Checkpoints.BlockNumber}, ${Fields.Checkpoints.ContractAddress})
+      PRIMARY KEY (${Fields.Checkpoints.Id})
     );`;
 
     sql += `\nCREATE TABLE IF NOT EXISTS ${Table.Metadata} (
@@ -106,7 +121,8 @@ export class CheckpointsStore {
     }
     await this.mysql.queryAsync(`INSERT IGNORE INTO ${Table.Checkpoints} VALUES ?`, [
       checkpoints.map(checkpoint => {
-        return [checkpoint.blockNumber, checkpoint.contractAddress];
+        const id = getCheckpointId(checkpoint.contractAddress, checkpoint.blockNumber);
+        return [id, checkpoint.blockNumber, checkpoint.contractAddress];
       })
     ]);
   }

--- a/test/unit/checkpoint/stores/__snapshots__/checkpoints.test.ts.snap
+++ b/test/unit/checkpoint/stores/__snapshots__/checkpoints.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckpointsStore createStore should execute correct query 1`] = `
+Array [
+  Array [
+    "CREATE TABLE IF NOT EXISTS _checkpoints (
+      id VARCHAR(10) NOT NULL,
+      block_number BIGINT NOT NULL,
+      contract_address VARCHAR(66) NOT NULL,
+      PRIMARY KEY (id)
+    );
+CREATE TABLE IF NOT EXISTS _metadata (
+      id VARCHAR(20) NOT NULL,
+      value VARCHAR(128) NOT NULL,
+      PRIMARY KEY (id)
+    );",
+  ],
+]
+`;
+
+exports[`CheckpointsStore insertCheckpoints should should execute correct query 1`] = `
+Array [
+  Array [
+    "INSERT IGNORE INTO _checkpoints VALUES ?",
+    Array [
+      Array [
+        Array [
+          "a739beda26",
+          5000,
+          "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
+        ],
+        Array [
+          "d2b8dcc2b5",
+          123222,
+          "0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3",
+        ],
+      ],
+    ],
+  ],
+]
+`;

--- a/test/unit/checkpoint/stores/__snapshots__/checkpoints.test.ts.snap
+++ b/test/unit/checkpoint/stores/__snapshots__/checkpoints.test.ts.snap
@@ -9,7 +9,7 @@ Array [
       contract_address VARCHAR(66) NOT NULL,
       PRIMARY KEY (id)
     );
-CREATE TABLE IF NOT EXISTS _metadata (
+CREATE TABLE IF NOT EXISTS _metadatas (
       id VARCHAR(20) NOT NULL,
       value VARCHAR(128) NOT NULL,
       PRIMARY KEY (id)

--- a/test/unit/checkpoint/stores/checkpoints.test.ts
+++ b/test/unit/checkpoint/stores/checkpoints.test.ts
@@ -1,0 +1,52 @@
+import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
+import { AsyncMySqlPool } from '../../../../src/checkpoint';
+import { CheckpointsStore, getCheckpointId } from '../../../../src/checkpoint/stores/checkpoints';
+import { Logger } from '../../../../src/checkpoint/utils/logger';
+
+describe('CheckpointsStore', () => {
+  let store: CheckpointsStore;
+  let mockMysql: AsyncMySqlPool & DeepMockProxy<AsyncMySqlPool>;
+  let logger: Logger & DeepMockProxy<Logger>;
+
+  beforeEach(() => {
+    mockMysql = mockDeep<AsyncMySqlPool>();
+    logger = mockDeep<Logger>({
+      child: () => mockDeep()
+    });
+    store = new CheckpointsStore(mockMysql, logger);
+  });
+
+  describe('createStore', () => {
+    it('should execute correct query', async () => {
+      await store.createStore();
+
+      expect(mockMysql.queryAsync.mock.calls).toMatchSnapshot();
+    });
+  });
+
+  describe('insertCheckpoints', () => {
+    it('should should execute correct query', async () => {
+      const checkpoints = [
+        {
+          contractAddress: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
+          blockNumber: 5000
+        },
+        {
+          contractAddress: '0x0625dc1290b6e936be5f1a3e963cf629326b1f4dfd5a56738dea98e1ad31b7f3',
+          blockNumber: 123222
+        }
+      ];
+      await store.insertCheckpoints(checkpoints);
+
+      expect(mockMysql.queryAsync.mock.calls).toMatchSnapshot();
+
+      // verify id is properly computed
+      const queryParams = mockMysql.queryAsync.mock.calls[0][1];
+      const firstBlockInput = queryParams[0][0];
+
+      expect(firstBlockInput[0]).toEqual(
+        getCheckpointId(checkpoints[0].contractAddress, checkpoints[0].blockNumber)
+      );
+    });
+  });
+});


### PR DESCRIPTION
This exposes _checkpoint and _checkpoints query through GraphQL using
the entity controllers logic.

It also adds an id column to the checkpoints table and computes the id
value as the last 10 hex bytes of the sha256(contract+block) value.

<img width="1615" alt="Screenshot 2022-05-06 at 8 19 53 am" src="https://user-images.githubusercontent.com/3120013/167085691-6c04b649-8f2f-4b48-970c-2a3e73e23a49.png">


Resolves #40