### PR TITLE
fix: include type dependencies and exclude test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint src/ test/ --ext .ts",
     "lint:fix": "eslint src/ test/ --ext .ts --fix",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "dev": "nodemon src/index.ts",
     "start": "node dist/src/index.js",
     "test": "jest"
@@ -15,6 +15,11 @@
     "@ethersproject/bignumber": "^5.6.0",
     "@snapshot-labs/checkpoint": "^0.1.0-beta.0",
     "@snapshot-labs/sx": "^0.1.0-beta.0",
+    "@types/bn.js": "^5.1.0",
+    "@types/express": "^4.17.11",
+    "@types/jest": "^27.5.0",
+    "@types/mysql": "^2.15.21",
+    "@types/node": "^17.0.24",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "eslint": "8.15.0",
@@ -25,11 +30,6 @@
     "typescript": "^4.6.4"
   },
   "devDependencies": {
-    "@types/bn.js": "^5.1.0",
-    "@types/express": "^4.17.11",
-    "@types/jest": "^27.5.0",
-    "@types/mysql": "^2.15.21",
-    "@types/node": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.22.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["test/**/*.spec.ts", "test/**/*.test.ts"]
+}


### PR DESCRIPTION
This moves type dependencies away from dev dependencies.And it also exlcudes tests from final builds.