### PR TITLE
chore: add /ping route for testing RTT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ const PORT = process.env.PORT || 3000;
 app.use(express.json({ limit: '4mb' }));
 app.use(express.urlencoded({ limit: '4mb', extended: false }));
 app.use(cors({ maxAge: 86400 }));
+app.get('/ping', (req, res) => res.send({ status: 'ok' }));
 app.use('/', checkpoint.graphql);
 
 app.listen(PORT, () => console.log(`Listening at http://localhost:${PORT}`));


### PR DESCRIPTION
This PR adds dummy `/ping` route so we can test what is RTT for very simple requests so we can better understand what introduces delay in requests.