### PR TITLE
feat: track goerli2 deployment

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -2,8 +2,8 @@
   "network_node_url": "https://starknet-goerli.infura.io/v3/46a5dd9727bf48d4a132672d3f376146",
   "sources": [
     {
-      "contract": "0x2121c175922cef8870b6b6b956d01a7ac75af034dfbb9135698f88644b17ea3",
-      "start": 345862,
+      "contract": "0xe1e511e496a72791ab3d591ba7d571a32de4261d84e4d183f26b6325970e20",
+      "start": 14808,
       "events": [
         {
           "name": "space_deployed",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,3 +66,12 @@ export function getSpaceName(address) {
   const noun = faker.word.noun(6);
   return `${noun.charAt(0).toUpperCase()}${noun.slice(1)} DAO`;
 }
+
+export function parseTimestamps(timestamps: string) {
+  const result = timestamps.replace('0x', '').match(/.{8}/g);
+  if (!result) return null;
+
+  const [snapshot, start, minEnd, maxEnd] = result.map(timestamp => parseInt(`0x${timestamp}`, 16));
+
+  return { snapshot, start, minEnd, maxEnd };
+}

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -1,7 +1,7 @@
 import { formatUnits } from '@ethersproject/units';
 import { shortStringArrToStr } from '@snapshot-labs/sx/dist/utils/strings';
 import { validateAndParseAddress } from 'starknet';
-import { getJSON, toAddress, getEvent, getSpaceName } from './utils';
+import { getJSON, toAddress, getEvent, getSpaceName, parseTimestamps } from './utils';
 import type { CheckpointWriter } from '@snapshot-labs/checkpoint';
 
 function intSequenceToString(intSequence) {
@@ -59,7 +59,7 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, event, mysql 
 
   console.log('Handle propose');
   const format =
-    'proposal, author, quorum(uint256), snapshot, start, min_end, max_end, executor, execution_hash, metadata_uri_len, metadata_uri(felt*)';
+    'proposal, author, quorum(uint256), timestamps, execution_strategy, execution_hash, metadata_uri_len, metadata_uri(felt*)';
   const data: any = getEvent(event.data, format);
 
   const space = validateAndParseAddress(event.from_address);
@@ -87,6 +87,9 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, event, mysql 
     console.log(JSON.stringify(e).slice(0, 256));
   }
 
+  const timestamps = parseTimestamps(data.timestamps);
+  if (!timestamps) return;
+
   const item = {
     id: `${space}/${proposal}`,
     proposal_id: proposal,
@@ -98,11 +101,11 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, event, mysql 
     body,
     discussion,
     execution,
-    start: parseInt(BigInt(data.start).toString()),
-    end: parseInt(BigInt(data.max_end).toString()),
-    min_end: parseInt(BigInt(data.min_end).toString()),
-    max_end: parseInt(BigInt(data.max_end).toString()),
-    snapshot: parseInt(BigInt(data.snapshot).toString()),
+    start: parseInt(BigInt(timestamps.start).toString()),
+    end: parseInt(BigInt(timestamps.maxEnd).toString()),
+    min_end: parseInt(BigInt(timestamps.minEnd).toString()),
+    max_end: parseInt(BigInt(timestamps.maxEnd).toString()),
+    snapshot: parseInt(BigInt(timestamps.snapshot).toString()),
     scores_1: 0,
     scores_2: 0,
     scores_3: 0,


### PR DESCRIPTION
## Summary

Tracks Goerli2 deployment

**`NETWORK_NODE_URL` needs to be set to goerli2 URL. Default one won't work. Chainstack supports Goerli2**

## Test plan

- Nuke your DB (remove mysql container and run `docker volume prune`).
- Run `NETWORK_NODE_URL=abc yarn dev`.
- Wait to reach block ~18550k.

Run this query:
```gql
query {
  spaces {
    id
    name,
    created
  }
  proposals {
    space {
      id
      strategies
    }
    author {
      id
    }
  },
  votes {
    id
    voter {
      id
    }
    vp
  }
}
```