### PR TITLE
chore: remove end proposal param

### DIFF
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -33,7 +33,6 @@ type Proposal {
   discussion: Text
   execution: Text
   start: Int
-  end: Int
   min_end: Int
   max_end: Int
   snapshot: Int

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -102,7 +102,6 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, event, mysql 
     discussion,
     execution,
     start: parseInt(BigInt(timestamps.start).toString()),
-    end: parseInt(BigInt(timestamps.maxEnd).toString()),
     min_end: parseInt(BigInt(timestamps.minEnd).toString()),
     max_end: parseInt(BigInt(timestamps.maxEnd).toString()),
     snapshot: parseInt(BigInt(timestamps.snapshot).toString()),


### PR DESCRIPTION
This param shouldn't be used anymore on the UI, it come from initial deployment where we did not have min and max proposal duration.