### PR TITLE
fix: read executors from correct property

### DIFF
--- a/src/writer.ts
+++ b/src/writer.ts
@@ -39,7 +39,7 @@ export const handleSpaceCreated: CheckpointWriter = async ({
     strategies: JSON.stringify(event.voting_strategies),
     strategies_params: JSON.stringify(event.voting_strategy_params_flat),
     authenticators: JSON.stringify(event.authenticators),
-    executors: JSON.stringify(event.executors),
+    executors: JSON.stringify(event.execution_strategies),
     proposal_count: 0,
     vote_count: 0,
     created: block.timestamp,


### PR DESCRIPTION
## Summary

It's available under `execution_strategies`, not old `executors`.