### PR TITLE
feat: handle space metadata changes

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -24,6 +24,10 @@
         {
           "name": "vote_created",
           "fn": "handleVote"
+        },
+        {
+          "name": "metadata_uri_updated",
+          "fn": "handleMetadataUriUpdated"
         }
       ]
     }


### PR DESCRIPTION
## Summary

This will index space metadata (initial and after its changed).

## Test plan

- Sync to latest or change start to `69380` to see latest deployments.

Run this query:
```gql
{
  spaces {
    name
    about
  }
}
```

Lynchee DAO should have about section updated.