### PR TITLE
fix: use correct metadataUri in space_deployed event

### DIFF
--- a/src/writer.ts
+++ b/src/writer.ts
@@ -48,7 +48,7 @@ export const handleSpaceCreated: CheckpointWriter = async ({
   };
 
   try {
-    const metadataUri = shortStringArrToStr(event.new_metadata_uri).replaceAll('\x00', '');
+    const metadataUri = shortStringArrToStr(event.metadata_uri).replaceAll('\x00', '');
     const metadata: any = await getJSON(metadataUri);
 
     if (metadata.name) item.name = metadata.name;


### PR DESCRIPTION
## Summary

When deploying metadata is under `metadata_uri`

## Test plan

Change start to `71450` and run this query:
```gql
{
  spaces(orderBy: created, orderDirection: desc) {
    name
    about
  }
}
```

It should return
```json
{
  "data": {
    "spaces": [
      {
        "name": "Lychee DAO",
        "about": "Hello!"
      }
    ]
  }
}
```