### PR TITLE
feat: add field for compatibility

### DIFF
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -20,10 +20,12 @@ type Space {
   strategies_params: [String]
   authenticators: [String]
   executors: [String]
+  executors_types: [String]
   proposal_count: Int
   vote_count: Int
   created: Int
   tx: String
+  executed: Boolean
   proposals: [Proposal]! @derivedFrom(field: "space")
 }
 


### PR DESCRIPTION
This PR adds `executed` and `executions_types` for compatbility with sx-subgraph. This way we can query both with same GraphQL client.