### PR TITLE
feat: use pg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,17 @@ services:
       - MYSQL_DATABASE=checkpoint
     volumes:
       - mysql:/var/lib/mysql
+  postgres:
+    image: postgres:15.2
+    ports:
+      - '5432:5432'
+    environment:
+      - POSTGRES_PASSWORD=default_password
+      - POSTGRES_DB=checkpoint
+    volumes:
+      - postgres:/var/lib/postgresql/data
 volumes:
   mysql:
+    driver: local
+  postgres:
     driver: local


### PR DESCRIPTION
Depends on: https://github.com/snapshot-labs/sx-api/pull/177
Depends on: https://github.com/snapshot-labs/checkpoint/pull/207

This PR demonstrates Checkpoint usage with `knex` to achieve support for any SQL DB. Writer side can use `mysql` or `pg`, depending on what database client is used.

## Test plan
- Use `docker-compose up -d` to start postgres instance.
- Change your DATABASE_URL: `DATABASE_URL=postgres://postgres:default_password@localhost:5432/checkpoint`
- Run `yarn dev`.
- It should work.

