### PR TITLE
fix: handle proposals without execution strategy

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,6 +88,8 @@ export function getVoteValue(label: string) {
 
 export async function handleExecutionStrategy(address: string, payload: string[]) {
   try {
+    if (address === '0x0') return null;
+
     const executionContract = new Contract(ExecutionStrategyAbi, address, starkProvider);
 
     const executionStrategyType = shortString.decodeShortString(


### PR DESCRIPTION
Closes: https://github.com/snapshot-labs/sx-api/issues/188

When creating proposal without execution we set execution strategy to 0 address. We need to exit early if we detect it.