### PR TITLE
feat: index voting power validation strategy metadata

### DIFF
--- a/src/schema.gql
+++ b/src/schema.gql
@@ -20,6 +20,9 @@ type Space {
   validation_strategy_params: String!
   voting_power_validation_strategy_strategies: [String]!
   voting_power_validation_strategy_strategies_params: [String]!
+  voting_power_validation_strategy_metadata: String!
+  voting_power_validation_strategies_parsed_metadata: [VotingPowerValidationStrategiesParsedMetadataItem]!
+    @derivedFrom(field: "space")
   proposal_count: Int!
   vote_count: Int!
   created: Int!
@@ -44,6 +47,13 @@ type SpaceMetadataItem {
   wallet: String!
   executors: [String]!
   executors_types: [String]!
+}
+
+type VotingPowerValidationStrategiesParsedMetadataItem {
+  id: String!
+  space: Space!
+  index: Int!
+  data: StrategiesParsedMetadataDataItem
 }
 
 type StrategiesParsedMetadataItem {

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -11,6 +11,7 @@ import {
   getVoteValue,
   handleExecutionStrategy,
   handleStrategiesMetadata,
+  handleVotingPowerValidationMetadata,
   longStringToText
 } from './utils';
 
@@ -55,6 +56,9 @@ export const handleSpaceCreated: CheckpointWriter = async ({ block, tx, event })
   space.validation_strategy_params = event.proposal_validation_strategy.params.join(',');
   space.voting_power_validation_strategy_strategies = [];
   space.voting_power_validation_strategy_strategies_params = [];
+  space.voting_power_validation_strategy_metadata = longStringToText(
+    event.proposal_validation_strategy_metadata_uri
+  );
   space.proposal_count = 0;
   space.vote_count = 0;
   space.created = block?.timestamp ?? getCurrentTimestamp();
@@ -77,6 +81,15 @@ export const handleSpaceCreated: CheckpointWriter = async ({ block, tx, event })
       space.voting_power_validation_strategy_strategies_params = parsed.allowed_strategies.map(
         strategy => strategy.params.map(param => `0x${param.toString(16)}`).join(',')
       );
+    }
+
+    try {
+      await handleVotingPowerValidationMetadata(
+        space.id,
+        space.voting_power_validation_strategy_metadata
+      );
+    } catch (e) {
+      console.log('failed to handle voting power strategies metadata', e);
     }
   }
   try {


### PR DESCRIPTION
We need to index voting power validation strategy metadata to get metadata for underlying strategies.

## Test plan
```gql
{
  space(id: "0x05091e35029b32c9ef95a3020b263bd6ff4ce0119e640cf8ca299b83e15e6d58") {
    id
    strategies_metadata
    strategies_parsed_metadata {
      id
      index
      data {
        name
        payload
      }
    }
    voting_power_validation_strategies_parsed_metadata {
      id
      index
      data {
        name
        payload
      }
    }
  }
}
```