### PR TITLE
feat: index strategies changes

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -67,6 +67,26 @@
         {
           "name": "OwnershipTransferred",
           "fn": "handleOwnershipTransferred"
+        },
+        {
+          "name": "AuthenticatorsAdded",
+          "fn": "handleAuthenticatorsAdded"
+        },
+        {
+          "name": "AuthenticatorsRemoved",
+          "fn": "handleAuthenticatorsRemoved"
+        },
+        {
+          "name": "VotingStrategiesAdded",
+          "fn": "handleVotingStrategiesAdded"
+        },
+        {
+          "name": "VotingStrategiesRemoved",
+          "fn": "handleVotingStrategiesRemoved"
+        },
+        {
+          "name": "ProposalValidationStrategyUpdated",
+          "fn": "handleProposalValidationStrategyUpdated"
         }
       ]
     }

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -11,6 +11,8 @@ type Space {
   min_voting_period: Int!
   max_voting_period: Int!
   proposal_threshold: Int!
+  next_strategy_index: Int!
+  strategies_indicies: [Int]!
   strategies: [String]!
   strategies_params: [String]!
   strategies_metadata: [String]!
@@ -89,6 +91,7 @@ type Proposal {
   execution_strategy_type: String!
   timelock_veto_guardian: String
   timelock_delay: Int
+  strategies_indicies: [Int]!
   strategies: [String]!
   strategies_params: [String]!
   scores_1: BigDecimalVP!

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,6 +128,7 @@ export async function handleExecutionStrategy(address: string, payload: string[]
 export async function handleStrategiesMetadata(
   spaceId: string,
   metadataUris: string[],
+  startingIndex: number,
   type:
     | typeof StrategiesParsedMetadataItem
     | typeof VotingPowerValidationStrategiesParsedMetadataItem = StrategiesParsedMetadataItem
@@ -135,15 +136,15 @@ export async function handleStrategiesMetadata(
   for (let i = 0; i < metadataUris.length; i++) {
     const metadataUri = metadataUris[i];
 
-    // this needs to include space as multiple spaces can reference identical metadata (same CID)
-    const uniqueId = `${spaceId}/${dropIpfs(metadataUri)}`;
+    const index = startingIndex + i;
+    const uniqueId = `${spaceId}/${index}/${dropIpfs(metadataUri)}`;
 
     const exists = await type.loadEntity(uniqueId);
     if (exists) continue;
 
     const strategiesParsedMetadataItem = new type(uniqueId);
     strategiesParsedMetadataItem.space = spaceId;
-    strategiesParsedMetadataItem.index = i;
+    strategiesParsedMetadataItem.index = index;
 
     if (metadataUri.startsWith('ipfs://')) {
       strategiesParsedMetadataItem.data = dropIpfs(metadataUri);
@@ -164,6 +165,7 @@ export async function handleVotingPowerValidationMetadata(spaceId: string, metad
   await handleStrategiesMetadata(
     spaceId,
     metadata.strategies_metadata,
+    0,
     VotingPowerValidationStrategiesParsedMetadataItem
   );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,17 @@
 import fetch from 'node-fetch';
-import { Contract, Provider, hash, shortString } from 'starknet';
+import { CallData, Contract, Provider, hash, shortString } from 'starknet';
 import { Contract as EthContract } from '@ethersproject/contracts';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { faker } from '@faker-js/faker';
 import { getAddress } from '@ethersproject/address';
 import { BigNumber } from '@ethersproject/bignumber';
+import { utils } from '@snapshot-labs/sx';
 import {
+  Space,
   StrategiesParsedMetadataItem,
   VotingPowerValidationStrategiesParsedMetadataItem
 } from '../.checkpoint/models';
+import EncodersAbi from './abis/encoders.json';
 import ExecutionStrategyAbi from './abis/executionStrategy.json';
 import SimpleQuorumExecutionStrategyAbi from './abis/l1/SimpleQuorumExecutionStrategy.json';
 import Config from './config.json';
@@ -22,6 +25,10 @@ const starkProvider = new Provider({
     nodeUrl: Config.network_node_url
   }
 });
+
+const PROPOSITION_POWER_PROPOSAL_VALIDATION_STRATEGY =
+  '0x38f034f17941669555fca61c43c67a517263aaaab833b26a1ab877a21c0bb6d';
+const encodersAbi = new CallData(EncodersAbi);
 
 export function getCurrentTimestamp() {
   return Math.floor(Date.now() / 1000);
@@ -122,6 +129,48 @@ export async function handleExecutionStrategy(address: string, payload: string[]
     console.log('failed to get execution strategy type', e);
 
     return null;
+  }
+}
+
+export async function updateProposaValidationStrategy(
+  space: Space,
+  validationStrategyAddress: string,
+  validationStrategyParams: string[],
+  metadataUri: string[]
+) {
+  space.validation_strategy = validationStrategyAddress;
+  space.validation_strategy_params = validationStrategyParams.join(',');
+  space.voting_power_validation_strategy_strategies = [];
+  space.voting_power_validation_strategy_strategies_params = [];
+  space.voting_power_validation_strategy_metadata = longStringToText(metadataUri);
+
+  if (
+    utils.encoding.hexPadLeft(validationStrategyAddress) ===
+    utils.encoding.hexPadLeft(PROPOSITION_POWER_PROPOSAL_VALIDATION_STRATEGY)
+  ) {
+    const parsed = encodersAbi.parse(
+      'proposition_power_params',
+      validationStrategyParams
+    ) as Record<string, any>;
+
+    if (Object.keys(parsed).length !== 0) {
+      space.proposal_threshold = parsed.proposal_threshold;
+      space.voting_power_validation_strategy_strategies = parsed.allowed_strategies.map(
+        strategy => `0x${strategy.address.toString(16)}`
+      );
+      space.voting_power_validation_strategy_strategies_params = parsed.allowed_strategies.map(
+        strategy => strategy.params.map(param => `0x${param.toString(16)}`).join(',')
+      );
+    }
+
+    try {
+      await handleVotingPowerValidationMetadata(
+        space.id,
+        space.voting_power_validation_strategy_metadata
+      );
+    } catch (e) {
+      console.log('failed to handle voting power strategies metadata', e);
+    }
   }
 }
 

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -35,7 +35,7 @@ export const handleSpaceCreated: CheckpointWriter = async ({ block, tx, event })
 
   if (!event || !tx.transaction_hash) return;
 
-  const strategies = event.voting_strategies.map(strategy => strategy.address);
+  const strategies: string[] = event.voting_strategies.map(strategy => strategy.address);
   const strategiesParams = event.voting_strategies.map(strategy => strategy.params.join(',')); // different format than sx-evm
   const strategiesMetadataUris = event.voting_strategy_metadata_uris.map(array =>
     longStringToText(array)
@@ -48,7 +48,9 @@ export const handleSpaceCreated: CheckpointWriter = async ({ block, tx, event })
   space.min_voting_period = Number(BigInt(event.min_voting_duration).toString());
   space.max_voting_period = Number(BigInt(event.max_voting_duration).toString());
   space.proposal_threshold = 0;
+  space.strategies_indicies = strategies.map((_, i) => i);
   space.strategies = strategies;
+  space.next_strategy_index = strategies.length;
   space.strategies_params = strategiesParams;
   space.strategies_metadata = strategiesMetadataUris;
   space.authenticators = event.authenticators;
@@ -102,7 +104,7 @@ export const handleSpaceCreated: CheckpointWriter = async ({ block, tx, event })
   }
 
   try {
-    await handleStrategiesMetadata(space.id, strategiesMetadataUris);
+    await handleStrategiesMetadata(space.id, strategiesMetadataUris, 0);
   } catch (e) {
     console.log('failed to handle strategies metadata', e);
   }
@@ -191,6 +193,153 @@ export const handleVotingDelayUpdated: CheckpointWriter = async ({ rawEvent, eve
   await space.save();
 };
 
+export const handleAuthenticatorsAdded: CheckpointWriter = async ({ rawEvent, event }) => {
+  if (!event || !rawEvent) return;
+
+  console.log('Handle space authenticators added');
+
+  const spaceId = validateAndParseAddress(rawEvent.from_address);
+
+  const space = await Space.loadEntity(spaceId);
+  if (!space) return;
+
+  space.authenticators = [...new Set([...space.authenticators, ...event.authenticators])];
+
+  await space.save();
+};
+
+export const handleAuthenticatorsRemoved: CheckpointWriter = async ({ rawEvent, event }) => {
+  if (!event || !rawEvent) return;
+
+  console.log('Handle space authenticators removed');
+
+  const spaceId = validateAndParseAddress(rawEvent.from_address);
+
+  const space = await Space.loadEntity(spaceId);
+  if (!space) return;
+
+  space.authenticators = space.authenticators.filter(
+    authenticator => !event.authenticators.includes(authenticator)
+  );
+
+  await space.save();
+};
+
+export const handleVotingStrategiesAdded: CheckpointWriter = async ({ rawEvent, event }) => {
+  if (!event || !rawEvent) return;
+
+  console.log('Handle space voting strategies added');
+
+  const spaceId = validateAndParseAddress(rawEvent.from_address);
+
+  const space = await Space.loadEntity(spaceId);
+  if (!space) return;
+
+  const initialNextStrategy = space.next_strategy_index;
+
+  const strategies = event.voting_strategies.map(strategy => strategy.address);
+  const strategiesParams = event.voting_strategies.map(strategy => strategy.params.join(','));
+  const strategiesMetadataUris = event.voting_strategy_metadata_uris.map(array =>
+    longStringToText(array)
+  );
+
+  space.strategies_indicies = [
+    ...space.strategies_indicies,
+    ...strategies.map((_, i) => space.next_strategy_index + i)
+  ];
+  space.strategies = [...space.strategies, ...strategies];
+  space.next_strategy_index += strategies.length;
+  space.strategies_params = [...space.strategies_params, ...strategiesParams];
+  space.strategies_metadata = [...space.strategies_metadata, ...strategiesMetadataUris];
+
+  try {
+    await handleStrategiesMetadata(space.id, strategiesMetadataUris, initialNextStrategy);
+  } catch (e) {
+    console.log('failed to handle strategies metadata', e);
+  }
+
+  await space.save();
+};
+
+export const handleVotingStrategiesRemoved: CheckpointWriter = async ({ rawEvent, event }) => {
+  if (!event || !rawEvent) return;
+
+  console.log('Handle space voting strategies removed');
+
+  const spaceId = validateAndParseAddress(rawEvent.from_address);
+
+  const space = await Space.loadEntity(spaceId);
+  if (!space) return;
+
+  const indiciesToRemove = event.voting_strategy_indices.map((index: string) =>
+    space.strategies_indicies.indexOf(parseInt(index))
+  );
+
+  space.strategies_indicies = space.strategies_indicies.filter(
+    (_, i) => !indiciesToRemove.includes(i)
+  );
+  space.strategies = space.strategies.filter((_, i) => !indiciesToRemove.includes(i));
+  space.strategies_params = space.strategies_params.filter((_, i) => !indiciesToRemove.includes(i));
+  space.strategies_metadata = space.strategies_metadata.filter(
+    (_, i) => !indiciesToRemove.includes(i)
+  );
+
+  await space.save();
+};
+
+export const handleProposalValidationStrategyUpdated: CheckpointWriter = async ({
+  rawEvent,
+  event
+}) => {
+  if (!event || !rawEvent) return;
+
+  console.log('Handle space proposal validation strategy updated');
+
+  const spaceId = validateAndParseAddress(rawEvent.from_address);
+
+  const space = await Space.loadEntity(spaceId);
+  if (!space) return;
+
+  space.validation_strategy = event.proposal_validation_strategy.address;
+  space.validation_strategy_params = event.proposal_validation_strategy.params.join(',');
+  space.voting_power_validation_strategy_strategies = [];
+  space.voting_power_validation_strategy_strategies_params = [];
+  space.voting_power_validation_strategy_metadata = longStringToText(
+    event.proposal_validation_strategy_metadata_uri
+  );
+
+  if (
+    utils.encoding.hexPadLeft(event.proposal_validation_strategy.address) ===
+    utils.encoding.hexPadLeft(PROPOSITION_POWER_PROPOSAL_VALIDATION_STRATEGY)
+  ) {
+    const parsed = encodersAbi.parse(
+      'proposition_power_params',
+      event.proposal_validation_strategy.params
+    ) as Record<string, any>;
+
+    if (Object.keys(parsed).length !== 0) {
+      space.proposal_threshold = parsed.proposal_threshold;
+      space.voting_power_validation_strategy_strategies = parsed.allowed_strategies.map(
+        strategy => `0x${strategy.address.toString(16)}`
+      );
+      space.voting_power_validation_strategy_strategies_params = parsed.allowed_strategies.map(
+        strategy => strategy.params.map(param => `0x${param.toString(16)}`).join(',')
+      );
+    }
+
+    try {
+      await handleVotingPowerValidationMetadata(
+        space.id,
+        space.voting_power_validation_strategy_metadata
+      );
+    } catch (e) {
+      console.log('failed to handle voting power strategies metadata', e);
+    }
+  }
+
+  await space.save();
+};
+
 export const handlePropose: CheckpointWriter = async ({ block, tx, rawEvent, event }) => {
   if (!rawEvent || !event || !tx.transaction_hash) return;
 
@@ -224,6 +373,7 @@ export const handlePropose: CheckpointWriter = async ({ block, tx, rawEvent, eve
   proposal.scores_3 = '0';
   proposal.scores_total = '0';
   proposal.quorum = 0n;
+  proposal.strategies_indicies = space.strategies_indicies;
   proposal.strategies = space.strategies;
   proposal.strategies_params = space.strategies_params;
   proposal.created = created;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,9 +1302,9 @@
     "@babel/types" "^7.3.0"
 
 "@types/bn.js@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.0.tgz#32c5d271503a12653c62cf4d2b45e6eab8cebc68"
-  integrity sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-5.1.2.tgz#162f5238c46f4bcbac07a98561724eca1fcf0c5e"
+  integrity sha512-dkpZu0szUtn9UXTmw+e0AJFd4D2XAxDnsCLdc05SfqpqzPEBft8eQr8uaFitfo/dUUOZERaLec2hHMG87A4Dxg==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
Indexing strategy changes is a bit tricky due to how they are managed (strategies are not removed, but just deactivated, but actual indexes need to be known still to select them when voting).

This is the best way of handling those I found that reduces number of changes on UI.
1. When adding strategies we keep track of `next_strategy_index` and `strategy_indicies`. `strategies`, `strategies_params` and `strategies_metadata` only show active strategies.
2. When removing we use `strategy_indicies` to figure out how to change `strategies` (and related arrays).
3. Strategies parsed metadata is not cleared as it's not part of Space/Proposal, but 1-to-n relation, so UI needs to do mapping for those.