### PR TITLE
fix: add voting power as numbers

### DIFF
--- a/src/writer.ts
+++ b/src/writer.ts
@@ -471,8 +471,10 @@ export const handleVote: CheckpointWriter = async ({ block, tx, rawEvent, event 
   const proposal = await Proposal.loadEntity(`${spaceId}/${proposalId}`);
   if (proposal) {
     proposal.vote_count += 1;
-    proposal.scores_total += vote.vp;
-    proposal[`scores_${vote.choice}`] += vote.vp;
+    proposal.scores_total = (BigInt(proposal.scores_total) + BigInt(vote.vp)).toString();
+    proposal[`scores_${vote.choice}`] = (
+      BigInt(proposal[`scores_${vote.choice}`]) + BigInt(vote.vp)
+    ).toString();
     await proposal.save();
   }
 };


### PR DESCRIPTION
### Summary

scores is now `BigDecimal` because `bigint` type was too small in PostgreSQL in some cases. As it's decimal it gets converted to string on JS side. We need to add them as BigInts, otherwise we are just concatenating those strings.

We could create our own BigInt type with custom precision to handle this better (https://github.com/checkpoint-labs/checkpoint/issues/272).